### PR TITLE
docs(index.rst): Fix title underline

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,5 +1,5 @@
 Welcome to ladybug-dotnet's documentation!
-===================================
+==========================================
 
 .. toctree::
    :maxdepth: 2


### PR DESCRIPTION
Hi @chriswmackey 

Everything looks good from the get-go with the already included configuration templates and the couple of files without any issues. I only fixed the minor warning of the index.rst title underline being too short.

I look forward to get going into the wiki project. I actually arrived to Denver today to join Sophia for the next couple of weeks but I have many hours between meetings to continue with our work. This weekend is pretty open if that works for you, I'm available Saturday between 10am and 5pm and Sunday between 9am to 3pm. Please let me know if any of those times work for you.

